### PR TITLE
Update symfony/filesytem dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.4",
         "behat/behat": "^3.0.0",
-        "symfony/filesystem": "^2.7"
+        "symfony/filesystem": ">=2.3 || ^3.0.0"
     },
     "require-dev": {
         "phpspec/phpspec": "2.4.0-alpha2",


### PR DESCRIPTION
This extension only uses the Symfony\Component\Filesystem->dumpFile() method, which was added in 2.3.0 and is present in the current version (3.3.0). Source: https://github.com/symfony/filesystem/blob/master/CHANGELOG.md